### PR TITLE
Feature/autohide

### DIFF
--- a/Settings.ui
+++ b/Settings.ui
@@ -268,6 +268,42 @@
                 </object>
               </child>
               <child>
+                <object class="GtkListBoxRow" id="hide_buttons_listboxrow">
+                  <child>
+                    <object class="GtkGrid" id="hide_buttons_grid">
+                      <property name="margin_left">12</property>
+                      <property name="margin_right">12</property>
+                      <property name="margin_top">12</property>
+                      <property name="margin_bottom">12</property>
+                      <property name="column_spacing">12</property>
+                      <child>
+                        <object class="GtkLabel" id="hide_buttons_label">
+                          <property name="hexpand">True</property>
+                          <property name="xalign">0</property>
+                          <property name="label" translatable="yes">Autohide buttons</property>
+                          <property name="wrap">True</property>
+                        </object>
+                        <packing>
+                          <property name="left_attach">0</property>
+                          <property name="top_attach">1</property>
+                        </packing>
+                      </child>
+                      <child>
+                        <object class="GtkSwitch" id="hide_buttons_switch">
+                          <property name="halign">end</property>
+                          <property name="valign">center</property>
+                        </object>
+                        <packing>
+                          <property name="left_attach">1</property>
+                          <property name="top_attach">0</property>
+                          <property name="height">2</property>
+                        </packing>
+                      </child>
+                    </object>
+                  </child>
+                </object>
+              </child>
+              <child>
                 <object class="GtkListBoxRow" id="automatic_theme_listboxrow">
                   <child>
                     <object class="GtkGrid" id="automatic_theme_grid">

--- a/buttons.js
+++ b/buttons.js
@@ -6,6 +6,7 @@ const Main = imports.ui.main;
 const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const St = imports.gi.St;
+const Tweener = imports.ui.tweener;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -35,12 +36,18 @@ function WARN(message) {
 }
 
 // Functions for changing opacity (to act as auto-hiding)
-function b_hidden(box, event) {
-    box.opacity = 0;
+function b_hidden(box) {
+  Tweener.addTween(box,
+                   { opacity: 0,
+                     time: 1/6,
+                     transition: 'linear'});
 }
 
-function b_shown(box, event) {
-    box.opacity = 255;
+function b_shown(box) {
+  Tweener.addTween(box,
+                   { opacity: 255,
+                     time: 1/6,
+                     transition: 'linear'});
 }
 
 /**

--- a/buttons.js
+++ b/buttons.js
@@ -34,6 +34,15 @@ function WARN(message) {
     }
 }
 
+// Functions for changing opacity (to act as auto-hiding)
+function b_hidden(box, event) {
+    box.opacity = 0;
+}
+
+function b_shown(box, event) {
+    box.opacity = 255;
+}
+
 /**
  * Buttons
  */
@@ -88,6 +97,22 @@ var Buttons = new Lang.Class({
             actor.add_actor(boxes[i]);
         });
 
+        // Adding buttons into a "container" that will ac
+        let container = new St.BoxLayout({track_hover: true, reactive: true});
+        container.add_actor(actors[1]);
+        // Enable\Disable "autohide" function when switch is changed from settings
+        this._settings.connect('changed::hide-buttons',
+        Lang.bind(this, function() {
+          if (this._settings.get_boolean('hide-buttons')) {
+            container.opacity = 0;
+            container.connect('enter-event', b_shown);
+            container.connect('leave-event', b_hidden);
+          } else {
+            container.opacity = 255;
+            container.connect('leave-event', b_shown);
+          }
+        }));
+
         let order = new Gio.Settings({schema_id: DCONF_META_PATH}).get_string('button-layout');
         LOG('Buttons layout : ' + order);
 
@@ -141,20 +166,28 @@ var Buttons = new Lang.Class({
                     case Position.BEFORE_NAME: {
                         let activitiesBox = Main.panel.statusArea.activities.actor.get_parent()
                         let leftBox = activitiesBox.get_parent();
-                        leftBox.insert_child_above(actors[1], activitiesBox);
+                        //leftBox.insert_child_above(actors[1], activitiesBox);
+                        // Change it to show the container
+                        leftBox.insert_child_above(container, activitiesBox);
                         break;
                     }
                     case Position.AFTER_NAME: {
                         let appMenuBox = Main.panel.statusArea.appMenu.actor.get_parent()
                         let leftBox = appMenuBox.get_parent();
-                        leftBox.insert_child_above(actors[1], appMenuBox);
+                        //leftBox.insert_child_above(actors[1], appMenuBox);
+                        // Change it to show the container
+                        leftBox.insert_child_above(container, appMenuBox);
                         break;
                     }
                     case Position.WITHIN_STATUS_AREA:
-                        Main.panel._rightBox.insert_child_at_index(actors[1], Main.panel._rightBox.get_children().length - 1);
+                        //Main.panel._rightBox.insert_child_at_index(actors[1], Main.panel._rightBox.get_children().length - 1);
+                        // Change it to show the container
+                        Main.panel._rightBox.insert_child_at_index(container, Main.panel._rightBox.get_children().length - 1);
                         break;
                     case Position.AFTER_STATUS_AREA:
-                        Main.panel._rightBox.add(actors[1]);
+                        //Main.panel._rightBox.add(actors[1]);
+                        // Change it to show the container
+                        Main.panel._rightBox.add(container);
                         break;
                 }
             }

--- a/buttons.js
+++ b/buttons.js
@@ -112,6 +112,14 @@ var Buttons = new Lang.Class({
             container.connect('leave-event', b_shown);
           }
         }));
+        if (this._settings.get_boolean('hide-buttons')) {
+            container.opacity = 0;
+            container.connect('enter-event', b_shown);
+            container.connect('leave-event', b_hidden);
+          } else {
+            container.opacity = 255;
+            container.connect('leave-event', b_shown);
+          }
 
         let order = new Gio.Settings({schema_id: DCONF_META_PATH}).get_string('button-layout');
         LOG('Buttons layout : ' + order);

--- a/buttons.js
+++ b/buttons.js
@@ -97,7 +97,7 @@ var Buttons = new Lang.Class({
             actor.add_actor(boxes[i]);
         });
 
-        // Adding buttons into a "container" that will ac
+        // Adding buttons into a "container"
         let container = new St.BoxLayout({track_hover: true, reactive: true});
         container.add_actor(actors[1]);
         // Enable\Disable "autohide" function when switch is changed from settings

--- a/prefs.js
+++ b/prefs.js
@@ -33,6 +33,13 @@ function buildPrefsWidget(){
         Gio.SettingsBindFlags.DEFAULT
     );
 
+    // Autohide button
+    settings.bind('hide-buttons',
+        buildable.get_object('hide_buttons_switch'),
+        'active',
+        Gio.SettingsBindFlags.DEFAULT
+    );
+
     // Buttons:
     buildable.get_object('button_position').set_active(settings.get_enum('button-position'));
     buildable.get_object('button_position').connect('changed', Lang.bind (this, function(widget) {

--- a/schemas/org.gnome.shell.extensions.no-title-bar.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.no-title-bar.gschema.xml
@@ -47,6 +47,12 @@
         <description>The app-menu uses the app-name as the label for the button. Use instead the window title of the focused window.</description>
     </key>
 
+    <key name="hide-buttons" type="b">
+      <default>true</default>
+        <summary>Autohide buttons.</summary>
+        <description>Works when buttons are set after app menu.</description>
+    </key>
+
     <key name="ignore-list-type" enum="org.gnome.shell.extensions.no-title-bar.ignoreListType">
       <default>'disabled'</default>
         <summary>Choose from disabled, whitelist or blacklist.</summary>


### PR DESCRIPTION
Buttons are hidden when pointer isn't hovering over them:
![no-buttons](https://user-images.githubusercontent.com/24315888/29746182-902efdd6-8ada-11e7-9dc7-1a941b31b5b9.png) ![with-buttons](https://user-images.githubusercontent.com/24315888/29746183-902fa312-8ada-11e7-9c51-395de41656eb.png)


Update: Seems like there was a bug where settings reset after unlocking screen. I fixed it but I don't know what to do next.. Sorry, I'm just new to this :(

Update: My bad, I still don't know how things work here very well. Seems like it was updated. I'm sorry again.