### PR TITLE
Improved button vertical alignment

### DIFF
--- a/buttons.js
+++ b/buttons.js
@@ -78,8 +78,8 @@ var Buttons = new Lang.Class({
         this._destroyButtons();
 
         actors = [
-            new St.Bin({ style_class: 'box-bin'}),
-            new St.Bin({ style_class: 'box-bin'})
+            new St.Bin({ style_class: 'box-bin', y_align: St.Align.START }),
+            new St.Bin({ style_class: 'box-bin', y_align: St.Align.START })
         ];
 
         boxes = [

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -15,7 +15,7 @@
 /* The style for each individual window button */
 .box-bin .window-button {
 	width: 24px;
-	height: 20px;
+	height: 24px;
 }
 
 /* The style for the window button when hovered over */


### PR DESCRIPTION
The window buttons tend to hang a couple of pixels away from the top edge of the screen. Other themes might need adjusting, I just use default.