### PR TITLE
Hide buttons for blacklisted or not whitelisted windows

### DIFF
--- a/buttons.js
+++ b/buttons.js
@@ -330,9 +330,15 @@ var Buttons = new Lang.Class({
             let win = Utils.getWindow(includeSnapped);
             if (win) {
                 visible = win.decorated;
-                // If still visible, check if on primary monitor
-                if (visible && this._settings.get_boolean('only-main-monitor'))
-                    visible = win.is_on_primary_monitor();
+
+                if (visible) {
+                    visible = !Utils.isWindowIgnored(this._settings, win);
+
+                    // If still visible, check if on primary monitor
+                    if (visible && this._settings.get_boolean('only-main-monitor')) {
+                        visible = win.is_on_primary_monitor();
+                    }
+                }
             }
         }
 

--- a/decoration.js
+++ b/decoration.js
@@ -10,14 +10,7 @@ const Config = imports.misc.config;
 const Util = imports.misc.util;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Prefs = Me.imports.prefs;
 const Utils = Me.imports.utils;
-
-const IgnoreList = {
-    DISABLED:  0,
-    WHITELIST: 1,
-    BLACKLIST: 2,
-}
 
 const WindowState = {
     DEFAULT: 'default',
@@ -245,7 +238,7 @@ var Decoration = new Lang.Class({
     /**
      * Get the value of _GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED before
      * no-title-bar did its magic.
-     * 
+     *
      * @param {Meta.Window} win - the window to check the property
      */
     _getOriginalState: function (win) {
@@ -293,40 +286,6 @@ var Decoration = new Lang.Class({
         return win._noTitleBarOriginalState = WindowState.DEFAULT;
     },
 
-    _filterBlacklist: function(win) {
-        if (this._settings.get_enum('ignore-list-type') === IgnoreList.DISABLED) {
-            return true;
-        }
-
-        let index_type = -1; // Exclude packages
-        if (this._settings.get_enum('ignore-list-type') === IgnoreList.WHITELIST) {
-            index_type = 0;
-        }
-
-        let ignoreList = this._settings.get_string('ignore-list');
-        ignoreList = Prefs.splitEntries(ignoreList);
-
-        let filterOut = false;
-
-        let appList = Utils.getAppList();
-        appList.forEach(function(appInfo) {
-            let index = ignoreList.indexOf(appInfo.get_name());
-            if (index > 0)
-                index = 0;
-            if (index !== index_type)
-                return;
-
-            let app = appSys.lookup_app(appInfo.get_id());
-            let windows = app.get_windows();
-            windows.forEach(function(iWin) {
-                if (iWin === win)
-                    filterOut = true;
-            });
-        });
-
-        return filterOut;
-    },
-
     /**
      * Tells the window manager to hide the titlebar on maximised windows.
      *
@@ -336,7 +295,7 @@ var Decoration = new Lang.Class({
      *
      * **Caveat**: doesn't work with Ubuntu's Ambiance and Radiance window themes -
      * my guess is they don't respect or implement this property.
-     * 
+     *
      * I don't know how to read the inital value, so I'm not sure how to resore it.
      *
      * @param {Meta.Window} win - window to set the HIDE_TITLEBAR_WHEN_MAXIMIZED property of.
@@ -344,7 +303,7 @@ var Decoration = new Lang.Class({
      */
     _setHideTitlebar: function(win, hide) {
         // Check if the window is a black/white-list
-        if (!this._filterBlacklist(win) && hide) {
+        if (Utils.isWindowIgnored(this._settings, win) && hide) {
             return;
         }
 

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,12 @@
 const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 const Meta = imports.gi.Meta;
+const Shell = imports.gi.Shell;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Prefs = Me.imports.prefs;
+
+const appSys = Shell.AppSystem.get_default();
 
 const MAXIMIZED = Meta.MaximizeFlags.BOTH;
 const VERTICAL = Meta.MaximizeFlags.VERTICAL;
@@ -99,4 +105,37 @@ function getAppList() {
     });
 
     return apps;
+}
+
+const IgnoreList = {
+    DISABLED: 0,
+    WHITELIST: 1,
+    BLACKLIST: 2,
+}
+
+function getAppInfoOf(window) {
+    return getAppList()
+        .find(function (appInfo) {
+            const app = appSys.lookup_app(appInfo.get_id());
+            return app.get_windows().includes(window);
+        });
+}
+
+function isWindowIgnored(settings, win) {
+    const listType = settings.get_enum('ignore-list-type');
+    if (listType === IgnoreList.DISABLED) return false;
+
+    let ignoreList = settings.get_string('ignore-list');
+    ignoreList = Prefs.splitEntries(ignoreList);
+
+    const appInfo = getAppInfoOf(win);
+    if (!appInfo) return false;
+
+    const isAppInList = ignoreList.includes(appInfo.get_name());
+
+    if (listType === IgnoreList.BLACKLIST) {
+        return isAppInList;
+    } else /* IgnoreList.WHITELIST */ {
+        return !isAppInList;
+    }
 }


### PR DESCRIPTION
This closes #79 by applying the `List` also to the buttons