### PR TITLE
Updates when only hiding title bar on primary monitor

### DIFF
--- a/buttons.js
+++ b/buttons.js
@@ -239,8 +239,9 @@ var Buttons = new Lang.Class({
     },
 
     _minimize: function() {
+        let onlyPrimaryMonitor = this._settings.get_boolean('only-main-monitor');
         let includeSnapped = this._settings.get_boolean('buttons-for-snapped');
-        let win = Utils.getWindow(includeSnapped);
+        let win = Utils.getWindow(includeSnapped, onlyPrimaryMonitor);
         if (!win || win.minimized) {
             return;
         }
@@ -249,8 +250,9 @@ var Buttons = new Lang.Class({
     },
 
     _maximize: function() {
+        let onlyPrimaryMonitor = this._settings.get_boolean('only-main-monitor');
         let includeSnapped = this._settings.get_boolean('buttons-for-snapped');
-        let win = Utils.getWindow(includeSnapped);
+        let win = Utils.getWindow(includeSnapped, onlyPrimaryMonitor);
         if (!win) {
             return;
         }
@@ -266,8 +268,9 @@ var Buttons = new Lang.Class({
     },
 
     _close: function() {
+        let onlyPrimaryMonitor = this._settings.get_boolean('only-main-monitor');
         let includeSnapped = this._settings.get_boolean('buttons-for-snapped');
-        let win = Utils.getWindow(includeSnapped);
+        let win = Utils.getWindow(includeSnapped, onlyPrimaryMonitor);
         if (!win) {
             return;
         }
@@ -326,8 +329,9 @@ var Buttons = new Lang.Class({
         let visible = !Main.overview.visible;
         if (visible) {
             visible = false;
+            let onlyPrimaryMonitor = this._settings.get_boolean('only-main-monitor');
             let includeSnapped = this._settings.get_boolean('buttons-for-snapped');
-            let win = Utils.getWindow(includeSnapped);
+            let win = Utils.getWindow(includeSnapped, onlyPrimaryMonitor);
             if (win) {
                 visible = win.decorated;
                 // If still visible, check if on primary monitor
@@ -351,6 +355,8 @@ var Buttons = new Lang.Class({
         return false;
     },
     _enableDragOnPanel: function() {
+        let settings = this._settings;
+
         this._originalFunction = Main.panel._onButtonPress;
 
         Main.panel._onButtonPress = function(actor, event) {
@@ -364,7 +370,8 @@ var Buttons = new Lang.Class({
             if (button != 1)
                 return Clutter.EVENT_PROPAGATE;
 
-            let focusWindow = Utils.getWindow(true);
+            let onlyPrimaryMonitor = settings.get_boolean('only-main-monitor');
+            let focusWindow = Utils.getWindow(true, onlyPrimaryMonitor);
             if (!focusWindow)
                 return Clutter.EVENT_PROPAGATE;
 

--- a/utils.js
+++ b/utils.js
@@ -5,11 +5,15 @@ const Meta = imports.gi.Meta;
 const MAXIMIZED = Meta.MaximizeFlags.BOTH;
 const VERTICAL = Meta.MaximizeFlags.VERTICAL;
 
-function getWindow(includeSnapped) {
+// Get the window to display the title bar for (buttons etc) or to drag from the top panel
+function getWindow(includeSnapped, onlyPrimaryMonitor) {
+    let primaryMonitor = global.screen.get_primary_monitor()
+
     // get all window in stacking order.
     let windows = global.display.sort_windows_by_stacking(
         global.screen.get_active_workspace().list_windows().filter(function (w) {
-            return w.get_window_type() !== Meta.WindowType.DESKTOP;
+            return w.get_window_type() !== Meta.WindowType.DESKTOP &&
+                (!onlyPrimaryMonitor || w.get_monitor() === primaryMonitor);
         })
     );
 


### PR DESCRIPTION
If only-main-monitor set:
  Always display buttons for maximized window on primary monitor even if a maximized window is focused on a different monitor
  Always allow drag of window on primary monitor from top panel even if a maximized window is focused on a different monitor

I think that it isn't always clear which application the min/max/close buttons are for, but that was the case before this change too.  Honestly it might even be a case of disentangling the window title from the AppMenu and just putting it next to the buttons.  

Closes #26 