### PR TITLE
Fix on Gnome 3.32

### DIFF
--- a/app_menu.js
+++ b/app_menu.js
@@ -23,9 +23,11 @@ var AppMenu = new Lang.Class({
         this._focusCallbackID = 0;
         this._tooltipCallbackID = 0;
         this._globalCallBackID = 0;
+        this._labelWidthCallbackID = 0;
         this._isEnabled = false;
 
         this._appMenu = Main.panel.statusArea.appMenu;
+        this._labelWidth = 0;
 
         this._activeWindow = null;
         this._awCallbackID = 0;
@@ -76,7 +78,7 @@ var AppMenu = new Lang.Class({
             let app = Shell.WindowTracker.get_default().get_window_app(win);
             title = app.get_name();
         }
-        this._appMenu._label.set_text(title);
+        this._appMenu._label.clutter_text.set_text(title);
         this._tooltip.text = title;
 
         return false;
@@ -246,6 +248,14 @@ var AppMenu = new Lang.Class({
         this._globalCallBackID = display.connect('restacked',
             Lang.bind(this, this._updateAppMenu));
 
+        this._labelWidthCallbackID = this._appMenu._label.connect("notify::width", () => {
+            var label_width = this._appMenu._label.width;
+            if (this._labelWidth !== label_width) {
+                this._labelWidth = label_width;
+                this._updateAppMenuWidth();
+            }
+        });
+
         this._labelId = this._settings.connect('changed::app-menu-width',
             Lang.bind(this, function() {
                 if (this._settings.get_boolean('change-appmenu'))
@@ -271,6 +281,11 @@ var AppMenu = new Lang.Class({
         if (this._globalCallBackID) {
             display.disconnect(this._globalCallBackID);
             this._globalCallBackID = 0;
+        }
+
+        if (this._labelWidthCallbackID) {
+            this._appMenu._label.disconnect(this._labelWidthCallbackID);
+            this._labelWidthCallbackID = 0;
         }
 
         if (this._tooltipCallbackID) {

--- a/decoration.js
+++ b/decoration.js
@@ -61,14 +61,6 @@ var Decoration = new Lang.Class({
             'notify::focus-window',
             Lang.bind(this, function () {
                 this._toggleTitlebar();
-
-                Mainloop.idle_add(Lang.bind(this, function () {
-                        // This is an ugly hack to force a reload of the application title in the titlebar
-                        let window_title = Main.panel._leftBox.get_children()[1].child._label.text;
-                        Main.panel._leftBox.get_children()[1].child._label.text = window_title + " ";
-                        Main.panel._leftBox.get_children()[1].child._label.text = window_title;
-                    })
-                );
             })
         );
 
@@ -407,7 +399,7 @@ var Decoration = new Lang.Class({
         let string = ByteArray.toString(result[1]);
         if (!string.match(/=/)) return;
 
-        string = string.split('=')[1].trim().split(',').map(part => {
+        string = string.split('=')[1].trim().split(',').map(function(part) {
             part = part.trim();
             return part.match(/\dx/) ? part : `0x${part}`
         });
@@ -457,14 +449,14 @@ var Decoration = new Lang.Class({
         if (!this._handleWindow(win))
             return;
 
-        GLib.idle_add(0, () => {
+        GLib.idle_add(0, Lang.bind(this, function() {
             let cmd = [];
             if (this._useMotifHints)
                 cmd = this._toggleDecorationsMotif(winId, hide);
             else
                 cmd = this._toggleDecorationsGtk(winId, hide);
             this._updateWindowAsync(win, cmd);
-        });
+        }));
     },
 
     _toggleDecorationsGtk: function (winId, hide) {

--- a/decoration.js
+++ b/decoration.js
@@ -57,14 +57,14 @@ var Decoration = new Lang.Class({
             })
         );
 
-        global.display.connect(
+        this._focusWindowID = global.display.connect(
             'notify::focus-window',
             Lang.bind(this, function () {
                 this._toggleTitlebar();
             })
         );
 
-        global.window_manager.connect(
+        this._sizeChangeID = global.window_manager.connect(
             'size-change',
             Lang.bind(this, function () {
                 this._toggleTitlebar();
@@ -137,6 +137,16 @@ var Decoration = new Lang.Class({
         if (this._windowEnteredID) {
             display.disconnect(this._windowEnteredID);
             this._windowEnteredID = 0;
+        }
+
+        if (this._focusWindowID) {
+            global.display.disconnect(this._focusWindowID);
+            this._focusWindowID = 0;
+        }
+
+        if (this._sizeChangeID) {
+            global.window_manager.disconnect(this._sizeChangeID);
+            this._sizeChangeID = 0;
         }
 
         this._cleanWorkspaces();

--- a/decoration.js
+++ b/decoration.js
@@ -548,7 +548,7 @@ var Decoration = new Lang.Class({
                 return false;
             }
 
-            let hide = win.get_maximised();
+            let hide = win.get_maximized();
             if (this._settings.get_boolean('only-main-monitor'))
                 hide = win.is_on_primary_monitor();
             this._setHideTitlebar(win, hide);

--- a/decoration.js
+++ b/decoration.js
@@ -61,6 +61,14 @@ var Decoration = new Lang.Class({
             'notify::focus-window',
             Lang.bind(this, function () {
                 this._toggleTitlebar();
+
+                Mainloop.idle_add(Lang.bind(this, function () {
+                        // This is an ugly hack to force a reload of the application title in the titlebar
+                        let window_title = Main.panel._leftBox.get_children()[1].child._label.text;
+                        Main.panel._leftBox.get_children()[1].child._label.text = window_title + " ";
+                        Main.panel._leftBox.get_children()[1].child._label.text = window_title;
+                    })
+                );
             })
         );
 

--- a/decoration.js
+++ b/decoration.js
@@ -548,7 +548,7 @@ var Decoration = new Lang.Class({
                 return false;
             }
 
-            let hide = true;
+            let hide = win.is_maximised();
             if (this._settings.get_boolean('only-main-monitor'))
                 hide = win.is_on_primary_monitor();
             this._setHideTitlebar(win, hide);
@@ -639,7 +639,7 @@ var Decoration = new Lang.Class({
     },
 
     _windowEnteredMonitor: function(metaScreen, monitorIndex, metaWin) {
-        let hide = true;
+        let hide = metaWin.get_maximized();
         if (this._settings.get_boolean('only-main-monitor'))
             hide = monitorIndex == Main.layoutManager.primaryIndex;
         this._setHideTitlebar(metaWin, hide);

--- a/decoration.js
+++ b/decoration.js
@@ -548,7 +548,7 @@ var Decoration = new Lang.Class({
                 return false;
             }
 
-            let hide = win.is_maximised();
+            let hide = win.get_maximised();
             if (this._settings.get_boolean('only-main-monitor'))
                 hide = win.is_on_primary_monitor();
             this._setHideTitlebar(win, hide);


### PR DESCRIPTION
I have tried to fix the extension on Gnome 3.32. I implemented an approach using _MOTIF_WM_HINTS as the extensions GTKTitlebar and Unite did. This meant that the extension now has to track the focused window, which added some complexity compared to the prior implementation.
After that the problem was that the width of the label in the appMenu was not computed correctly when the label-text is set by the extension (fixed in commits 3 and 4), which needed a workaround by tracking the width changes of that label and updating the title accordingly.
I tried to be as least invasive as possible and hope that this change would still work on older gnome versions, but I can't guarantee that. I hopefully tested all options of the extension, so the functionality is still working (blacklisting, only on main monitor, ...)

The code is a bit sluggish, I admit, but I would also like to refactor it again, once I've got more time. There is some functionality used in this extension, that is either deprecated, or not recommended to use (`Lang.bind`, `Mainloop`, ...). Problem with that is, that those changes might break functionality for older versions of Gnome (e.g. I don't know since when arrow-functions are a thing in gjs), so I stopped with this code here and will get to that sometime else. I also would like to add an optional debugging mode since I found it very hard to debug without really knowing, what the extension did.

If there is anything that I might need to optimize I will be glad to do so in order to get this extension working again for everyone, since as explained by many in #114 this is a very useful extension.

Best regards
Jonas